### PR TITLE
Refactor/Feat: Updated Books to auto create relationship with user

### DIFF
--- a/app/graphql/mutations/books/create_book.rb
+++ b/app/graphql/mutations/books/create_book.rb
@@ -9,14 +9,18 @@ class Mutations::Books::CreateBook < Mutations::BaseMutation
   argument :category, String, required: true
   argument :condition, String, required: true
   argument :available, Boolean, required: true
+  argument :user_id, Integer, required: true
 
   field :book, Types::BookType, null: false
   field :errors, [String], null: false
 
-  def resolve(google_book_id:, isbn_13:, pg_count:, description:, author:, book_title:, book_cover:, category:, condition:, available:)
+  def resolve(google_book_id:, isbn_13:, pg_count:, description:, author:, book_title:, book_cover:, category:, condition:, available:, user_id:)
     book = Book.new(google_book_id: google_book_id, isbn_13: isbn_13, pg_count: pg_count, description:description, book_title: book_title, author: author, book_cover: book_cover, category: category, condition: condition, available: available)
 
+
     if book.save
+      UserBook.create!(user_id: user_id, book_id: book.id, status: 0)
+
       {
         book: book,
         errors: []

--- a/spec/fixtures/Google_Books_Facade/Happy_Path/returns_an_array_of_google_book_objects_by_title.yml
+++ b/spec/fixtures/Google_Books_Facade/Happy_Path/returns_an_array_of_google_book_objects_by_title.yml
@@ -807,4 +807,889 @@ http_interactions:
           ]
         }
   recorded_at: Fri, 09 Dec 2022 21:50:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/books/v1/volumes/?key=<key>&q=Rhythm%20of%20War
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sat, 10 Dec 2022 19:05:28 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "kind": "books#volumes",
+          "totalItems": 1843,
+          "items": [
+            {
+              "kind": "books#volume",
+              "id": "QCPBDwAAQBAJ",
+              "etag": "PsiBrnH9ftk",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/QCPBDwAAQBAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "subtitle": "Book Four of The Stormlight Archive",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2020-11-17",
+                "description": "An instant #1 New York Times Bestseller and a USA Today and Indie Bestseller! The Stormlight Archive saga continues in Rhythm of War, the eagerly awaited sequel to Brandon Sanderson's #1 New York Times bestselling Oathbringer, from an epic fantasy writer at the top of his game. After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar’s crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin’s scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition’s envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781429952040"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1429952040"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 1374,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 11,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.14.11.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=QCPBDwAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=1&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&rdid=book-QCPBDwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=QCPBDwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "481EEAAAQBAJ",
+              "etag": "eHeqGH9nzTQ",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/481EEAAAQBAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "subtitle": "Book Four of The Stormlight Archive",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Fantasy",
+                "publishedDate": "2022-06-28",
+                "description": "The fourth book in the stormlight Archive series, Rhythm of War, marks the eagerly awaited sequel to the #1 New York Times bestselling Oathbringer, from epic fantasy writer Brandon Sanderson. After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar’s crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin’s scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition’s envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780765365309"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0765365308"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 0,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=481EEAAAQBAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=481EEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=481EEAAAQBAJ&dq=Rhythm+of+War&hl=&cd=2&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=481EEAAAQBAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War.html?hl=&id=481EEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=481EEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The fourth book in the stormlight Archive series, Rhythm of War, marks the eagerly awaited sequel to the #1 New York Times bestselling Oathbringer, from epic fantasy writer Brandon Sanderson."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "N093zgEACAAJ",
+              "etag": "tYov0SD6ONM",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/N093zgEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War Part Two",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Gollancz",
+                "publishedDate": "2022-04-28",
+                "description": "After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar's crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin's scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition's envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. The story will continue . . . Other books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0575093420"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780575093423"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 752,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=N093zgEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=N093zgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=N093zgEACAAJ&dq=Rhythm+of+War&hl=&cd=3&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=N093zgEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_Part_Two.html?hl=&id=N093zgEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=N093zgEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Brandon Sanderson&#39;s The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "PTBQEAAAQBAJ",
+              "etag": "l0ILCVICtLs",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/PTBQEAAAQBAJ",
+              "volumeInfo": {
+                "title": "The Lost Metal",
+                "subtitle": "A Mistborn Novel",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2022-11-15",
+                "description": "Return to #1 New York Times bestseller Brandon Sanderson’s Mistborn world of Scadrial as its second era, which began with The Alloy of Law, comes to its earth-shattering conclusion in The Lost Metal. For years, frontier lawman turned big-city senator Waxillium Ladrian has hunted the shadowy organization the Set—with his late uncle and his sister among their leaders—since they started kidnapping people with the power of Allomancy in their bloodlines. When Detective Marasi Colms and her partner Wayne find stockpiled weapons bound for the Outer City of Bilming, this opens a new lead. Conflict between Elendel and the Outer Cities only favors the Set, and their tendrils now reach to the Elendel Senate—whose corruption Wax and Steris have sought to expose—and Bilming is even more entangled. After Wax discovers a new type of explosive that can unleash unprecedented destruction and realizes that the Set must already have it, an immortal kandra serving Scadrial’s god, Harmony, reveals that Bilming has fallen under the influence of another god: Trell, worshipped by the Set. And Trell isn’t the only factor at play from the larger Cosmere—Marasi is recruited by offworlders with strange abilities who claim their goal is to protect Scadrial...at any cost. Wax must choose whether to set aside his rocky relationship with God and once again become the Sword that Harmony has groomed him to be. If no one steps forward to be the hero Scadrial needs, the planet and its millions of people will come to a sudden and calamitous ruin. Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Dawnshard (Novella) Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning The Lost Metal Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780765391209"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0765391201"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 541,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.6.5.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=PTBQEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=PTBQEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=PTBQEAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=4&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ&rdid=book-PTBQEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=PTBQEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Dawnshard (Novella) Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "90nDzQEACAAJ",
+              "etag": "Wn9jndDZ4BE",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/90nDzQEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War SIGNED EDITION",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publishedDate": "2020-11-17",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125079367X"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250793676"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 1232,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=90nDzQEACAAJ&dq=Rhythm+of+War&hl=&cd=5&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=90nDzQEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_SIGNED_EDITION.html?hl=&id=90nDzQEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=90nDzQEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The Stormlight Archive saga continues in Rhythm of War, the eagerly awaited sequel to Brandon Sanderson&#39;s #1 New York Times bestselling Oathbringer , from an epic fantasy writer at the top of his game.After forming a coalition of human ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "7mVUEAAAQBAJ",
+              "etag": "PqBlMkBlYe0",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/7mVUEAAAQBAJ",
+              "volumeInfo": {
+                "title": "Leech",
+                "authors": [
+                  "Hiron Ennes"
+                ],
+                "publisher": "Tordotcom",
+                "publishedDate": "2022-09-27",
+                "description": "A surreal and horrifying debut, Hiron Ennes's Leech defies our understanding of identity, heredity, and bodily autonomy. An Amazon Book of the Month! “A wonderful new entry to Gothic science fiction, impeccably clever and atmospheric. Think Wuthering Heights... with worms!”—Tamsyn Muir MEET THE CURE FOR THE HUMAN DISEASE In an isolated chateau, as far north as north goes, the baron’s doctor has died. The doctor’s replacement has a mystery to solve: discovering how the Institute lost track of one of its many bodies. For hundreds of years the Interprovincial Medical Institute has grown by taking root in young minds and shaping them into doctors, replacing every human practitioner of medicine. The Institute is here to help humanity, to cure and to cut, to cradle and protect the species from the apocalyptic horrors their ancestors unleashed. In the frozen north, the Institute's body will discover a competitor for its rung at the top of the evolutionary ladder. A parasite is spreading through the baron's castle, already a dark pit of secrets, lies, violence, and fear. The two will make war on the battlefield of the body. Whichever wins, humanity will lose again. At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250811196"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1250811198"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 230,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 3,
+                "ratingsCount": 2,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.2.2.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=7mVUEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=7mVUEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=7mVUEAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=6&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ&rdid=book-7mVUEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=7mVUEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": ". . I will follow this writer anywhere going forward.&quot; —Gillian Flynn, New York Times bestselling author of Gone Girl A surreal and horrifying debut, Hiron Ennes&#39;s Leech defies our understanding of identity, heredity, and bodily autonomy."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "NNt9zgEACAAJ",
+              "etag": "wd6eFITHND8",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/NNt9zgEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War Part One",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Gollancz",
+                "publishedDate": "2021-10",
+                "description": "After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar's crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin's scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition's envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. The story continues in Rhythm of War Part Two. Other books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0575093412"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780575093416"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 672,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=NNt9zgEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=NNt9zgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=NNt9zgEACAAJ&dq=Rhythm+of+War&hl=&cd=7&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=NNt9zgEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_Part_One.html?hl=&id=NNt9zgEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=NNt9zgEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Brandon Sanderson&#39;s The Cosmere The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Other Cosmere novels Elantris ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "q-przQEACAAJ",
+              "etag": "Sd3L4inYFIw",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/q-przQEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2020-11-04",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1250784263"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250784261"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=q-przQEACAAJ&dq=Rhythm+of+War&hl=&cd=8&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=q-przQEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War.html?hl=&id=q-przQEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=q-przQEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "&quot;After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "E649EAAAQBAJ",
+              "etag": "8CbGHeykRbI",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/E649EAAAQBAJ",
+              "volumeInfo": {
+                "title": "The Wilderwomen",
+                "subtitle": "A Novel",
+                "authors": [
+                  "Ruth Emmie Lang"
+                ],
+                "publisher": "St. Martin's Press",
+                "publishedDate": "2022-11-15",
+                "description": "\"Exquisitely drawn characters imbue Lang’s unconventional plot with verisimilitude and heart, inspiring readers to ponder whether the world is stranger and more beautiful than it appears. Effervescent, ethereal, and suffused with wonder.\" — Kirkus (starred review) \"Lang’s melancholy, atmospheric writing sets the perfect tone as the Wilder sisters unravel the mystery. The result is a cozy supernatural outing perfect for an autumn night.\" —Publisher's Weekly Ohioana Book Award finalist Ruth Emmie Lang returns with a new cast of ordinary characters with extraordinary abilities in The Wilderwomen. Five years ago, Nora Wilder disappeared. The older of her two daughters, Zadie, should have seen it coming, because she can literally see things coming. But not even her psychic abilities were able to prevent their mother from vanishing one morning. Zadie’s estranged younger sister, Finn, can’t see into the future, but she has an uncannily good memory, so good that she remembers not only her own memories, but the echoes of memories other people have left behind. On the afternoon of her graduation party, Finn is seized by an “echo” more powerful than anything she’s experienced before: a woman singing a song she recognizes, a song about a bird... When Finn wakes up alone in an aviary with no idea of how she got there, she realizes who the memory belongs to: Nora. Now, it’s up to Finn to convince her sister that not only is their mom still out there, but that she wants to be found. Against Zadie’s better judgement, she and Finn hit the highway, using Finn’s echoes to retrace Nora’s footsteps and uncover the answer to the question that has been haunting them for years: Why did she leave? But the more time Finn spends in their mother’s past, the harder it is for her to return to the present, to return to herself. As Zadie feels her sister start to slip away, she will have to decide what lengths she is willing to go to find their mother, knowing that if she chooses wrong, she could lose them both for good.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250246929"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125024692X"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 266,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 2,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "1.1.1.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=E649EAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=E649EAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=E649EAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=9&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ&rdid=book-E649EAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/The_Wilderwomen-sample-epub.acsm?id=E649EAAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=E649EAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The result is a cozy supernatural outing perfect for an autumn night.&quot; —Publisher&#39;s Weekly Ohioana Book Award finalist Ruth Emmie Lang returns with a new cast of ordinary characters with extraordinary abilities in The Wilderwomen."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "Ulk8EAAAQBAJ",
+              "etag": "h/gTRbkjw/E",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/Ulk8EAAAQBAJ",
+              "volumeInfo": {
+                "title": "Seasonal Fears",
+                "authors": [
+                  "Seanan McGuire"
+                ],
+                "publisher": "Tordotcom",
+                "publishedDate": "2022-05-03",
+                "description": "From New York Times bestselling author Seanan McGuire, Seasonal Fears is the extraordinary companion novel to Middlegame. The king of winter and the queen of summer are dead. The fight for their crowns begins! Melanie has a destiny, though it isn’t the one everyone assumes it to be. She’s delicate; she’s fragile; she’s dying. Now, truly, is the winter of her soul. Harry doesn’t want to believe in destiny, because that means accepting the loss of the one person who gives his life meaning, who brings summer to his world. So, when a new road is laid out in front of them—a road that will lead through untold dangers toward a possible lifetime together—walking down it seems to be the only option. But others are following behind, with violence in their hearts. It looks like Destiny has a plan for them, after all.... \"One must maintain a little bit of summer even in the middle of winter.\" —Thoreau At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250768254"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125076825X"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 544,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 3,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.1.1.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=Ulk8EAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=Ulk8EAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=Ulk8EAAAQBAJ&pg=PP1&dq=Rhythm+of+War&hl=&cd=10&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ&rdid=book-Ulk8EAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=Ulk8EAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "From New York Times bestselling author Seanan McGuire, Seasonal Fears is the extraordinary companion novel to Middlegame."
+              }
+            }
+          ]
+        }
+  recorded_at: Sat, 10 Dec 2022 19:05:28 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/Google_Books_Service/Happy_Path/returns_books_by_book_name.yml
+++ b/spec/fixtures/Google_Books_Service/Happy_Path/returns_books_by_book_name.yml
@@ -807,4 +807,889 @@ http_interactions:
           ]
         }
   recorded_at: Fri, 09 Dec 2022 21:50:41 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/books/v1/volumes/?key=<key>&q=Rhythm%20of%20War
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sat, 10 Dec 2022 19:05:30 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "kind": "books#volumes",
+          "totalItems": 1843,
+          "items": [
+            {
+              "kind": "books#volume",
+              "id": "QCPBDwAAQBAJ",
+              "etag": "hItaa05/f00",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/QCPBDwAAQBAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "subtitle": "Book Four of The Stormlight Archive",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2020-11-17",
+                "description": "An instant #1 New York Times Bestseller and a USA Today and Indie Bestseller! The Stormlight Archive saga continues in Rhythm of War, the eagerly awaited sequel to Brandon Sanderson's #1 New York Times bestselling Oathbringer, from an epic fantasy writer at the top of his game. After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar’s crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin’s scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition’s envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781429952040"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1429952040"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 1374,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 11,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.14.11.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=QCPBDwAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=1&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&rdid=book-QCPBDwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=QCPBDwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "481EEAAAQBAJ",
+              "etag": "mtbdQtyPNa4",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/481EEAAAQBAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "subtitle": "Book Four of The Stormlight Archive",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Fantasy",
+                "publishedDate": "2022-06-28",
+                "description": "The fourth book in the stormlight Archive series, Rhythm of War, marks the eagerly awaited sequel to the #1 New York Times bestselling Oathbringer, from epic fantasy writer Brandon Sanderson. After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar’s crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin’s scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition’s envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780765365309"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0765365308"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 0,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=481EEAAAQBAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=481EEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=481EEAAAQBAJ&dq=Rhythm+of+War&hl=&cd=2&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=481EEAAAQBAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War.html?hl=&id=481EEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=481EEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The fourth book in the stormlight Archive series, Rhythm of War, marks the eagerly awaited sequel to the #1 New York Times bestselling Oathbringer, from epic fantasy writer Brandon Sanderson."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "N093zgEACAAJ",
+              "etag": "ihFilBvwJXc",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/N093zgEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War Part Two",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Gollancz",
+                "publishedDate": "2022-04-28",
+                "description": "After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar's crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin's scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition's envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. The story will continue . . . Other books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0575093420"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780575093423"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 752,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=N093zgEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=N093zgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=N093zgEACAAJ&dq=Rhythm+of+War&hl=&cd=3&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=N093zgEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_Part_Two.html?hl=&id=N093zgEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=N093zgEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Brandon Sanderson&#39;s The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "PTBQEAAAQBAJ",
+              "etag": "dF5npuBYUns",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/PTBQEAAAQBAJ",
+              "volumeInfo": {
+                "title": "The Lost Metal",
+                "subtitle": "A Mistborn Novel",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2022-11-15",
+                "description": "Return to #1 New York Times bestseller Brandon Sanderson’s Mistborn world of Scadrial as its second era, which began with The Alloy of Law, comes to its earth-shattering conclusion in The Lost Metal. For years, frontier lawman turned big-city senator Waxillium Ladrian has hunted the shadowy organization the Set—with his late uncle and his sister among their leaders—since they started kidnapping people with the power of Allomancy in their bloodlines. When Detective Marasi Colms and her partner Wayne find stockpiled weapons bound for the Outer City of Bilming, this opens a new lead. Conflict between Elendel and the Outer Cities only favors the Set, and their tendrils now reach to the Elendel Senate—whose corruption Wax and Steris have sought to expose—and Bilming is even more entangled. After Wax discovers a new type of explosive that can unleash unprecedented destruction and realizes that the Set must already have it, an immortal kandra serving Scadrial’s god, Harmony, reveals that Bilming has fallen under the influence of another god: Trell, worshipped by the Set. And Trell isn’t the only factor at play from the larger Cosmere—Marasi is recruited by offworlders with strange abilities who claim their goal is to protect Scadrial...at any cost. Wax must choose whether to set aside his rocky relationship with God and once again become the Sword that Harmony has groomed him to be. If no one steps forward to be the hero Scadrial needs, the planet and its millions of people will come to a sudden and calamitous ruin. Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Dawnshard (Novella) Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning The Lost Metal Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780765391209"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0765391201"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 541,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.6.5.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=PTBQEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=PTBQEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=PTBQEAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=4&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ&rdid=book-PTBQEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=PTBQEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Dawnshard (Novella) Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "90nDzQEACAAJ",
+              "etag": "td1PD1HufXY",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/90nDzQEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War SIGNED EDITION",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publishedDate": "2020-11-17",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125079367X"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250793676"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 1232,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=90nDzQEACAAJ&dq=Rhythm+of+War&hl=&cd=5&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=90nDzQEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_SIGNED_EDITION.html?hl=&id=90nDzQEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=90nDzQEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The Stormlight Archive saga continues in Rhythm of War, the eagerly awaited sequel to Brandon Sanderson&#39;s #1 New York Times bestselling Oathbringer , from an epic fantasy writer at the top of his game.After forming a coalition of human ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "7mVUEAAAQBAJ",
+              "etag": "OzlkPYuHxy8",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/7mVUEAAAQBAJ",
+              "volumeInfo": {
+                "title": "Leech",
+                "authors": [
+                  "Hiron Ennes"
+                ],
+                "publisher": "Tordotcom",
+                "publishedDate": "2022-09-27",
+                "description": "A surreal and horrifying debut, Hiron Ennes's Leech defies our understanding of identity, heredity, and bodily autonomy. An Amazon Book of the Month! “A wonderful new entry to Gothic science fiction, impeccably clever and atmospheric. Think Wuthering Heights... with worms!”—Tamsyn Muir MEET THE CURE FOR THE HUMAN DISEASE In an isolated chateau, as far north as north goes, the baron’s doctor has died. The doctor’s replacement has a mystery to solve: discovering how the Institute lost track of one of its many bodies. For hundreds of years the Interprovincial Medical Institute has grown by taking root in young minds and shaping them into doctors, replacing every human practitioner of medicine. The Institute is here to help humanity, to cure and to cut, to cradle and protect the species from the apocalyptic horrors their ancestors unleashed. In the frozen north, the Institute's body will discover a competitor for its rung at the top of the evolutionary ladder. A parasite is spreading through the baron's castle, already a dark pit of secrets, lies, violence, and fear. The two will make war on the battlefield of the body. Whichever wins, humanity will lose again. At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250811196"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1250811198"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 230,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 3,
+                "ratingsCount": 2,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.2.2.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=7mVUEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=7mVUEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=7mVUEAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=6&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ&rdid=book-7mVUEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=7mVUEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": ". . I will follow this writer anywhere going forward.&quot; —Gillian Flynn, New York Times bestselling author of Gone Girl A surreal and horrifying debut, Hiron Ennes&#39;s Leech defies our understanding of identity, heredity, and bodily autonomy."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "NNt9zgEACAAJ",
+              "etag": "/SlWWZwlzFo",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/NNt9zgEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War Part One",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Gollancz",
+                "publishedDate": "2021-10",
+                "description": "After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar's crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin's scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition's envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. The story continues in Rhythm of War Part Two. Other books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0575093412"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780575093416"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 672,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=NNt9zgEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=NNt9zgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=NNt9zgEACAAJ&dq=Rhythm+of+War&hl=&cd=7&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=NNt9zgEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_Part_One.html?hl=&id=NNt9zgEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=NNt9zgEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Brandon Sanderson&#39;s The Cosmere The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Other Cosmere novels Elantris ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "q-przQEACAAJ",
+              "etag": "Q5TaCIDOHCE",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/q-przQEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2020-11-04",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1250784263"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250784261"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=q-przQEACAAJ&dq=Rhythm+of+War&hl=&cd=8&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=q-przQEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War.html?hl=&id=q-przQEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=q-przQEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "&quot;After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "E649EAAAQBAJ",
+              "etag": "KiY0AtJWhbc",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/E649EAAAQBAJ",
+              "volumeInfo": {
+                "title": "The Wilderwomen",
+                "subtitle": "A Novel",
+                "authors": [
+                  "Ruth Emmie Lang"
+                ],
+                "publisher": "St. Martin's Press",
+                "publishedDate": "2022-11-15",
+                "description": "\"Exquisitely drawn characters imbue Lang’s unconventional plot with verisimilitude and heart, inspiring readers to ponder whether the world is stranger and more beautiful than it appears. Effervescent, ethereal, and suffused with wonder.\" — Kirkus (starred review) \"Lang’s melancholy, atmospheric writing sets the perfect tone as the Wilder sisters unravel the mystery. The result is a cozy supernatural outing perfect for an autumn night.\" —Publisher's Weekly Ohioana Book Award finalist Ruth Emmie Lang returns with a new cast of ordinary characters with extraordinary abilities in The Wilderwomen. Five years ago, Nora Wilder disappeared. The older of her two daughters, Zadie, should have seen it coming, because she can literally see things coming. But not even her psychic abilities were able to prevent their mother from vanishing one morning. Zadie’s estranged younger sister, Finn, can’t see into the future, but she has an uncannily good memory, so good that she remembers not only her own memories, but the echoes of memories other people have left behind. On the afternoon of her graduation party, Finn is seized by an “echo” more powerful than anything she’s experienced before: a woman singing a song she recognizes, a song about a bird... When Finn wakes up alone in an aviary with no idea of how she got there, she realizes who the memory belongs to: Nora. Now, it’s up to Finn to convince her sister that not only is their mom still out there, but that she wants to be found. Against Zadie’s better judgement, she and Finn hit the highway, using Finn’s echoes to retrace Nora’s footsteps and uncover the answer to the question that has been haunting them for years: Why did she leave? But the more time Finn spends in their mother’s past, the harder it is for her to return to the present, to return to herself. As Zadie feels her sister start to slip away, she will have to decide what lengths she is willing to go to find their mother, knowing that if she chooses wrong, she could lose them both for good.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250246929"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125024692X"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 266,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 2,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "1.1.1.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=E649EAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=E649EAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=E649EAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=9&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ&rdid=book-E649EAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/The_Wilderwomen-sample-epub.acsm?id=E649EAAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=E649EAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The result is a cozy supernatural outing perfect for an autumn night.&quot; —Publisher&#39;s Weekly Ohioana Book Award finalist Ruth Emmie Lang returns with a new cast of ordinary characters with extraordinary abilities in The Wilderwomen."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "Ulk8EAAAQBAJ",
+              "etag": "EURCVbfLT4g",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/Ulk8EAAAQBAJ",
+              "volumeInfo": {
+                "title": "Seasonal Fears",
+                "authors": [
+                  "Seanan McGuire"
+                ],
+                "publisher": "Tordotcom",
+                "publishedDate": "2022-05-03",
+                "description": "From New York Times bestselling author Seanan McGuire, Seasonal Fears is the extraordinary companion novel to Middlegame. The king of winter and the queen of summer are dead. The fight for their crowns begins! Melanie has a destiny, though it isn’t the one everyone assumes it to be. She’s delicate; she’s fragile; she’s dying. Now, truly, is the winter of her soul. Harry doesn’t want to believe in destiny, because that means accepting the loss of the one person who gives his life meaning, who brings summer to his world. So, when a new road is laid out in front of them—a road that will lead through untold dangers toward a possible lifetime together—walking down it seems to be the only option. But others are following behind, with violence in their hearts. It looks like Destiny has a plan for them, after all.... \"One must maintain a little bit of summer even in the middle of winter.\" —Thoreau At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250768254"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125076825X"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 544,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 3,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.1.1.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=Ulk8EAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=Ulk8EAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=Ulk8EAAAQBAJ&pg=PP1&dq=Rhythm+of+War&hl=&cd=10&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ&rdid=book-Ulk8EAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=Ulk8EAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "From New York Times bestselling author Seanan McGuire, Seasonal Fears is the extraordinary companion novel to Middlegame."
+              }
+            }
+          ]
+        }
+  recorded_at: Sat, 10 Dec 2022 19:05:30 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/Types_QueryType/google_books_by_title/will_return_google_book_matching_google_book_id.yml
+++ b/spec/fixtures/Types_QueryType/google_books_by_title/will_return_google_book_matching_google_book_id.yml
@@ -338,4 +338,1002 @@ http_interactions:
           ]
         }
   recorded_at: Fri, 09 Dec 2022 21:31:08 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/books/v1/volumes/?key=<key>&q=QCPBDwAAQBAJ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sat, 10 Dec 2022 19:05:30 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "kind": "books#volumes",
+          "totalItems": 10,
+          "items": [
+            {
+              "kind": "books#volume",
+              "id": "QCPBDwAAQBAJ",
+              "etag": "STusUzPLfYY",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/QCPBDwAAQBAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "subtitle": "Book Four of The Stormlight Archive",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2020-11-17",
+                "description": "An instant #1 New York Times Bestseller and a USA Today and Indie Bestseller! The Stormlight Archive saga continues in Rhythm of War, the eagerly awaited sequel to Brandon Sanderson's #1 New York Times bestselling Oathbringer, from an epic fantasy writer at the top of his game. After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar’s crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin’s scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition’s envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781429952040"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1429952040"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 1374,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 11,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.14.11.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=QCPBDwAAQBAJ&printsec=frontcover&dq=QCPBDwAAQBAJ&hl=&cd=1&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&rdid=book-QCPBDwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=QCPBDwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "QcpBDwAAQBAJ",
+              "etag": "Pf+Hg+/YjSY",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/QcpBDwAAQBAJ",
+              "volumeInfo": {
+                "title": "Біле Ікло (з ілюстраціями)",
+                "authors": [
+                  "Джек Лондон"
+                ],
+                "publisher": "Litres",
+                "publishedDate": "2022-01-29",
+                "description": "Безкраї та суворі північні краї накладають відбиток на життя людей і тварин. Їх непереборна сила здатна зламати будь-кого, і тільки наймужніші та найвитриваліші здатні цю силу здолати. Саме таким і був головний герой повісті Джека Лондона – ні, не людина, а вовк на ймення Біле Ікло, що відмінно засвоїв науку виживати в будь-яких несприятливих умовах.Письменник в деталях описує психологію, мотиви поведінки і вчинки Білого Ікла, показує, як доброта і ласка по відношенню до живої істоти вчить його платити любов'ю за любов. А для розумного прирученого вовка любов була дорожча за життя.Ілюстрації Валерії Гогіної.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9785040938896"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "5040938896"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": true
+                },
+                "pageCount": 241,
+                "printType": "BOOK",
+                "categories": [
+                  "Juvenile Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "1.1.2.0.preview.3",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=QcpBDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=QcpBDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "uk",
+                "previewLink": "http://books.google.com/books?id=QcpBDwAAQBAJ&printsec=frontcover&dq=QCPBDwAAQBAJ&hl=&cd=2&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=QcpBDwAAQBAJ&dq=QCPBDwAAQBAJ&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/%D0%91%D1%96%D0%BB%D0%B5_%D0%86%D0%BA%D0%BB%D0%BE_%D0%B7_%D1%96%D0%BB%D1%8E%D1%81%D1%82%D1%80%D0%B0%D1%86%D1%96.html?hl=&id=QcpBDwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/%D0%91%D1%96%D0%BB%D0%B5_%D0%86%D0%BA%D0%BB%D0%BE_%D0%B7_%D1%96%D0%BB%D1%8E%D1%81%D1%82%D1%80%D0%B0%D1%86%D1%96-sample-epub.acsm?id=QcpBDwAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/%D0%91%D1%96%D0%BB%D0%B5_%D0%86%D0%BA%D0%BB%D0%BE_%D0%B7_%D1%96%D0%BB%D1%8E%D1%81%D1%82%D1%80%D0%B0%D1%86%D1%96-sample-pdf.acsm?id=QcpBDwAAQBAJ&format=pdf&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=QcpBDwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Безкраї та суворі північні краї накладають відбиток на життя людей і тварин. Їх непереборна сила здатна зламати будь-кого, і тільки ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "iJgQDgAAQBAJ",
+              "etag": "JGD2mvXBQMA",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/iJgQDgAAQBAJ",
+              "volumeInfo": {
+                "title": "Alcatraz vs. The Evil Librarians Series",
+                "subtitle": "(Alcatraz vs. The Evil Librarians, The Scrivener's Bones, The Knights of Crystallia, The Shattered Lens, The Dark Talent)",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2017-02-28",
+                "description": "This discounted ebundle includes: Alcatraz vs. The Evil Librarians, The Scrivener's Bones, The Knights of Crystallia, The Shattered Lens, The Dark Talent An action-packed fantasy adventure series by the #1 New York Times bestselling author Brandon Sanderson. Alcatraz Smedry and his family and friends must battle a cult of evil Librarians bent on taking over the world through misinformation and suppressing the truth. Alcatraz vs. the Evil Librarians — On his thirteenth birthday, foster child Alcatraz Smedry gets a bag of sand in the mail-his only inheritance from his father and mother. It is quickly stolen by the cult of Evil Librarians. Alcatraz must stop them, using the only weapon he has: an incredible talent for breaking things. The Scriveners Bones — In his second skirmish against the Evil Librarians who rule the world, Alcatraz and his ragtag crew of freedom fighters track Grandpa Smedry to the ancient and mysterious Library of Alexandria. Can Alcatraz and his friends rescue Grandpa Smedry and make it out of there alive? The Knights of Crystallia — Alcatraz Smedry has made it to the Free Kingdoms at last. Unfortunately, so have the Evil Librarians—including his mother! Now Alcatraz has to find a traitor among the Knights of Crystallia, make up with his estranged father, and save one of the last bastions of the Free Kingdoms from the Evil Librarians. The Shattered Lens — Alcatraz Smedry is up against a whole army of Evil Librarians with only his friend Bastille, a few pairs of glasses, and an unlimited supply of exploding teddy bears to help him. This time, even Alcatraz's extraordinary talent for breaking things may not be enough to defeat the army of Evil Librarians and their giant librarian robots. The Dark Talent — Alcatraz Smedry has successfully defeated the army of Evil Librarians and saved the kingdom of Mokia. Too bad he managed to break the Smedry Talents in the process. Even worse, his father is trying to enact a scheme that could ruin the world, and his friend, Bastille, is in a coma. Without his Talent to draw upon, can Alcatraz figure out a way to save Bastille and defeat the Evil Librarians once and for all? At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780765397447"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0765397447"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 1408,
+                "printType": "BOOK",
+                "categories": [
+                  "Juvenile Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.6.6.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=iJgQDgAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=iJgQDgAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=iJgQDgAAQBAJ&pg=PP1&dq=QCPBDwAAQBAJ&hl=&cd=3&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=iJgQDgAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=iJgQDgAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 39.16,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 39.16,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=iJgQDgAAQBAJ&rdid=book-iJgQDgAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 39160000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 39160000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=iJgQDgAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "qCpBDwAAQBAJ",
+              "etag": "vABfF5o3oD0",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/qCpBDwAAQBAJ",
+              "volumeInfo": {
+                "title": "Persoonlijkheidsdiagnostiek in de klinische praktijk",
+                "authors": [
+                  "W.M. Snellen"
+                ],
+                "publisher": "Springer",
+                "publishedDate": "2017-12-02",
+                "description": "Dit boek helpt klinische professionals om het uiterste uit hun psychodiagnostische onderzoeksmateriaal te halen. Het leert ze om de resultaten van persoonlijkheidsdiagnostiek optimaal te integreren en te interpreteren. Daarbij geeft het boek antwoord op vragen als: welke betekenis moet je toekennen aan psychische klachten en symptomen? En hoe kun je de resultaten van persoonlijkheidsdiagnostiek in een individuele context plaatsen? Zo krijgt de psychodiagnosticus een helder beeld van de veerkracht én de kwetsbaarheid van de cliënt. In Persoonlijkheidsdiagnostiek in de klinische praktijk wordt persoonlijkheidsonderzoek bij cliënten met psychopathologie voor het eerst behandeld uit het perspectief van de psychodiagnosticus zelf. De theoriegestuurde methodische visie en werkwijze worden in dit nieuwe standaardwerk geïllustreerd met casuïstiek, waarbij er ook aandacht is voor de belangrijkste valkuilen. De beslisbomen en stappenplannen ondersteunen de lezer bij zijn dagelijkse diagnostische werkzaamheden. Het boek is bestemd voor professionals werkzaam in de GGZ, zoals gz-psychologen, psychotherapeuten, klinisch psychologen, psychiaters en zij die daartoe in opleiding zijn. Wim Snellen is expert op het gebied van de persoonlijkheidsdiagnostiek. Hij werkte ruim veertig jaar als klinisch psycholoog in de psychiatrie en heeft uitgebreide ervaring met het geven van cursussen, supervisie en onderwijs in dit vakgebied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9789036819398"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "9036819393"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": true
+                },
+                "pageCount": 319,
+                "printType": "BOOK",
+                "categories": [
+                  "Psychology"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "0.0.1.0.preview.3",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=qCpBDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=qCpBDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "nl",
+                "previewLink": "http://books.google.com/books?id=qCpBDwAAQBAJ&printsec=frontcover&dq=QCPBDwAAQBAJ&hl=&cd=4&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=qCpBDwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=qCpBDwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE_AND_RENTAL",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 49.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 39.49,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=qCpBDwAAQBAJ&rdid=book-qCpBDwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 49990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 39490000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  },
+                  {
+                    "finskyOfferType": 3,
+                    "listPrice": {
+                      "amountInMicros": 17500000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 15220000,
+                      "currencyCode": "USD"
+                    },
+                    "rentalDuration": {
+                      "unit": "DAY",
+                      "count": 90
+                    }
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/Persoonlijkheidsdiagnostiek_in_de_klinis-sample-epub.acsm?id=qCpBDwAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/Persoonlijkheidsdiagnostiek_in_de_klinis-sample-pdf.acsm?id=qCpBDwAAQBAJ&format=pdf&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=qCpBDwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "In Persoonlijkheidsdiagnostiek in de klinische praktijk wordt persoonlijkheidsonderzoek bij cliënten met psychopathologie voor het eerst behandeld uit het perspectief van de psychodiagnosticus zelf."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "DGS8DwAAQBAJ",
+              "etag": "6n//8bSsaHY",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/DGS8DwAAQBAJ",
+              "volumeInfo": {
+                "title": "The Fires of Vengeance",
+                "authors": [
+                  "Evan Winter"
+                ],
+                "publisher": "Orbit",
+                "publishedDate": "2020-11-10",
+                "description": "In this \"relentlessly gripping, brilliant\" epic fantasy (James Islington), an ousted queen must join forces with a young warrior in order to reclaim her throne and save her people. Tau and his Queen, desperate to delay the impending attack on the capital by the indigenous people of Xidda, craft a dangerous plan. If Tau succeeds, the Queen will have the time she needs to assemble her forces and launch an all out assault on her own capital city, where her sister is being propped up as the 'true' Queen of the Omehi. If the city can be taken, if Tsiora can reclaim her throne, and if she can reunite her people then the Omehi have a chance to survive the onslaught. \"This gritty series set in a South African–inspired fantasy world is an intense reading experience, and the second book is just as phenomenal as the first.\"—BuzzFeed News \"The Fires of Vengeance is epic fantasy at its finest.\"—Winter Is Coming The Books of The Burning Series The Rage of Dragons The Fires of Vengeance The Lord of Demons",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780316489812"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0316489816"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 477,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.2.3.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=DGS8DwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=DGS8DwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=DGS8DwAAQBAJ&pg=PP1&dq=QCPBDwAAQBAJ&hl=&cd=5&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=DGS8DwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=DGS8DwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 9.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 9.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=DGS8DwAAQBAJ&rdid=book-DGS8DwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 9990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 9990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/The_Fires_of_Vengeance-sample-epub.acsm?id=DGS8DwAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=DGS8DwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "&quot;This gritty series set in a South African–inspired fantasy world is an intense reading experience, and the second book is just as phenomenal as the first.&quot;—BuzzFeed News &quot;The Fires of Vengeance is epic fantasy at its finest.&quot;—Winter ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "mwpNDwAAQBAJ",
+              "etag": "qdL2KMfzSho",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/mwpNDwAAQBAJ",
+              "volumeInfo": {
+                "title": "The Stormlight Archive, Books 1-3",
+                "subtitle": "The Way of Kings, Words of Radiance, Oathbringer",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2018-05-08",
+                "description": "This Stormlight Archive discounted ebundle includes: The Way of Kings, Words of Radiance, Oathbringer The #1 New York Times bestselling epic fantasy series by Brandon Sanderson! The Stormlight Archive is the wildly imaginative epic fantasy from New York Times bestselling author Brandon Sanderson: welcome to the remarkable world of Roshar, a world of stone and storms. Uncanny tempests of incredible power sweep across the rocky terrain so frequently that they have shaped ecology and civilization alike. Roshar is shared by humans and the enigmatic, humanoid Parshendi, with whom they are at war. It has been centuries since the fall of the ten consecrated orders known as the Knights Radiant, but their Shardblades and Shardplate remain. Men trade kingdoms for Shardblades. Wars were fought for them, and won by them, but in the war against the Parshendi, the ancient weapons and armor may not be enough. Speak again the ancient oaths: Life before death. Strength before weakness. Journey before Destination. and return to men the Shards they once bore. The Knights Radiant must stand again. --- Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250305411"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1250305411"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 3570,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 5,
+                "ratingsCount": 1,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.4.5.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=mwpNDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=mwpNDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=mwpNDwAAQBAJ&pg=PP1&dq=QCPBDwAAQBAJ&hl=&cd=6&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=mwpNDwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=mwpNDwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 25.58,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 25.58,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=mwpNDwAAQBAJ&rdid=book-mwpNDwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 25580000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 25580000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=mwpNDwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "--- Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "745CEAAAQBAJ",
+              "etag": "iu3CiuXpW+w",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/745CEAAAQBAJ",
+              "volumeInfo": {
+                "title": "Evershore (Skyward Flight: Novella 3)",
+                "authors": [
+                  "Brandon Sanderson",
+                  "Janci Patterson"
+                ],
+                "publisher": "Delacorte Press",
+                "publishedDate": "2021-12-28",
+                "description": "From #1 bestselling author Brandon Sanderson and Janci Patterson comes the final of three Skyward series novellas, each told from the perspective of a different member of the team back on Detritus. Listen to Jorgen's story along with Cytonic. With the government of Detritus in disarray because of Superiority treachery, and with Spensa still away on her mission in the Nowhere, Jorgen must work together with the alien Alanik to pick up the pieces. They intercept a strange transmission from the planet Evershore and its Kitsen inhabitants, who say they have some of Jorgen’s people and want to return them—but can the Kitsen be trusted? And can Jorgen learn to master his increasingly erratic cytonic powers before they spiral out of control and destroy all hope of forming an alliance against the Superiority? Praise for Skyward An Instant New York Times Bestseller A Kirkus Reviews Best Book of the Year • \"Startling revelations and stakes-raising implications . . . Sanderson plainly had a ball with this nonstop, highflying opener, and readers will too.\" —Kirkus Reviews, starred review • \"With this action-packed trilogy opener, Sanderson offers up a resourceful, fearless heroine and a memorable cast.\" —Publishers Weekly, starred review • \"It is impossible to turn the pages fast enough.\" —Booklist",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780593566633"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0593566637"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 208,
+                "printType": "BOOK",
+                "categories": [
+                  "Young Adult Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.1.1.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=745CEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=745CEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=745CEAAAQBAJ&printsec=frontcover&dq=QCPBDwAAQBAJ&hl=&cd=7&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=745CEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=745CEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 4.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 4.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=745CEAAAQBAJ&rdid=book-745CEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 4990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 4990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/Evershore_Skyward_Flight_Novella_3-sample-epub.acsm?id=745CEAAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=745CEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "From #1 bestselling author Brandon Sanderson and Janci Patterson comes the final of three Skyward series novellas, each told from the perspective of a different member of the team back on Detritus."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "QzJ9DwAAQBAJ",
+              "etag": "PdDOv51o+Ec",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/QzJ9DwAAQBAJ",
+              "volumeInfo": {
+                "title": "The Rage of Dragons",
+                "authors": [
+                  "Evan Winter"
+                ],
+                "publisher": "Orbit",
+                "publishedDate": "2019-02-12",
+                "description": "Game of Thrones meets Gladiator in this blockbuster debut epic fantasy about a world caught in an eternal war, and the young man who will become his people's only hope for survival. ONE OF TIME MAGAZINE'S TOP 100 FANTASY BOOKS OF ALL TIME Winner of the Reddit/Fantasy Award for Best Debut Fantasy Novel The Omehi people have been fighting an unwinnable war for almost two hundred years. The lucky ones are born gifted. One in every two thousand women has the power to call down dragons. One in every hundred men is able to magically transform himself into a bigger, stronger, faster killing machine. Everyone else is fodder, destined to fight and die in the endless war. Young, gift-less Tau knows all this, but he has a plan of escape. He's going to get himself injured, get out early, and settle down to marriage, children, and land. Only, he doesn't get the chance. Those closest to him are brutally murdered, and his grief swiftly turns to anger. Fixated on revenge, Tau dedicates himself to an unthinkable path. He'll become the greatest swordsman to ever live, a man willing to die a hundred thousand times for the chance to kill the three who betrayed him. The Rage of Dragons launches a stunning and powerful debut epic fantasy series that readers are already calling \"the best fantasy book in years.\" The BurningThe Rage of Dragons",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780316489744"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0316489743"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 544,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 9,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.8.9.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=QzJ9DwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=QzJ9DwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=QzJ9DwAAQBAJ&pg=PP1&dq=QCPBDwAAQBAJ&hl=&cd=8&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=QzJ9DwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=QzJ9DwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 9.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 9.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=QzJ9DwAAQBAJ&rdid=book-QzJ9DwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 9990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 9990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/The_Rage_of_Dragons-sample-epub.acsm?id=QzJ9DwAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=QzJ9DwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The Rage of Dragons launches a stunning and powerful debut epic fantasy series that readers are already calling &quot;the best fantasy book in years.&quot; The BurningThe Rage of Dragons"
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "yo5CEAAAQBAJ",
+              "etag": "hyfFuU8UT+8",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/yo5CEAAAQBAJ",
+              "volumeInfo": {
+                "title": "ReDawn (Skyward Flight: Novella 2)",
+                "authors": [
+                  "Brandon Sanderson",
+                  "Janci Patterson"
+                ],
+                "publisher": "Delacorte Press",
+                "publishedDate": "2021-10-26",
+                "description": "From #1 bestselling author Brandon Sanderson and Janci Patterson comes the second of three Skyward series novellas, each told from the perspective of a different member of the team back on Detritus. Read Alanik's story between Starsight and Cytonic. “Don’t trust their lies. Don’t trust their false peace.” That is the warning that Alanik of the planet ReDawn gave the human pilot Spensa after Alanik’s ship crash-landed on Detritus. While accepting an invitation to meet with her people’s enemy, the Galactic Superiority, Alanik heard Spensa’s cry for help across the vastness of space, and she used her cytonic powers to hyperjump her ship to the source of that cry. What she found there was a shock—a whole planet of free humans fighting against the Superiority. Were they the allies her people desperately needed? When she recovered from her injuries and met the friendly humans Jorgen and FM of Skyward Flight, she found that her warning to Spensa had gone unheeded by the government of Detritus, and they were considering a peace overture from the Superiority. Now having returned to ReDawn, Alanik is dismayed to learn that her own people are falling into the exact same trap. The faction in ReDawn’s government that wants to appease the Superiority has gained the upper hand. With Alanik’s mentor, Renakin captured, she has no one to turn to but Jorgen, FM, and their friend Rig. An ancient technology may have the power to save both of their planets from disaster, but can they discover its secrets before it’s too late? Praise for Skyward An Instant New York Times Bestseller A Kirkus Reviews Best Book of the Year • \"Startling revelations and stakes-raising implications . . . Sanderson plainly had a ball with this nonstop, highflying opener, and readers will too.\" —Kirkus Reviews, starred review • \"With this action-packed trilogy opener, Sanderson offers up a resourceful, fearless heroine and a memorable cast.\" —Publishers Weekly, starred review • \"It is impossible to turn the pages fast enough.\" —Booklist",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780593566626"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0593566629"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 208,
+                "printType": "BOOK",
+                "categories": [
+                  "Young Adult Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.2.2.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=yo5CEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=yo5CEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=yo5CEAAAQBAJ&printsec=frontcover&dq=QCPBDwAAQBAJ&hl=&cd=9&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=yo5CEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=yo5CEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 4.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 4.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=yo5CEAAAQBAJ&rdid=book-yo5CEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 4990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 4990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/ReDawn_Skyward_Flight_Novella_2-sample-epub.acsm?id=yo5CEAAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=yo5CEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "From #1 bestselling author Brandon Sanderson and Janci Patterson comes the second of three Skyward series novellas, each told from the perspective of a different member of the team back on Detritus."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "JlO_zgEACAAJ",
+              "etag": "s1kiUVYIaSc",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/JlO_zgEACAAJ",
+              "volumeInfo": {
+                "title": "Skyward Flight: The Collection",
+                "subtitle": "Sunreach, ReDawn, Evershore",
+                "authors": [
+                  "Brandon Sanderson",
+                  "Janci Patterson"
+                ],
+                "publisher": "Delacorte Press",
+                "publishedDate": "2022-04-05",
+                "description": "Return to the planet Detritus with FM, Alanik, and Jorgen in this must-have three-novella collection featuring exclusive character art and deleted scenes from Skyward with commentary from Brandon Sanderson. Journey with Skyward Flight to Detritus—humanity’s final refuge from the hostile Galactic Superiority government. In Skyward, Spensa Nightshade became a starfighter pilot in the Defiant Defense Force’s Skyward Flight to battle Superiority forces. In Starsight she impersonated the alien Alanik to infiltrate a Superiority space station and steal their hyperdrives. And in Cytonic she traveled the strange dimension of the Nowhere to discover the secrets of the planet-destroying Delvers and unlock her own Cytonic powers. As she is stuck in the Nowhere, Spensa’s companions FM and Jorgen in Skyward Flight are left on Detritus with a new mandate: figure out how to use the hyperdrives so that humanity can escape the planet and find allies among other species oppressed by the Superiority. First comes a distress call from Minister Cuna and other diones on the abandoned outpost of Sunreach. Alanik’s people on the planet ReDawn and the Kitsen from the planet Evershore also need Skyward Flight’s aid in their desperate battles. The tales of FM, Alanik, and Jorgen combine to expand the universe of the New York Times bestselling Skyward series to new action-packed heights. Once you’ve claimed the stars, can you keep them free?",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780593567852"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0593567854"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 641,
+                "printType": "BOOK",
+                "categories": [
+                  "Young Adult Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "0.2.0.0.preview.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=JlO_zgEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=JlO_zgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=JlO_zgEACAAJ&dq=QCPBDwAAQBAJ&hl=&cd=10&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=JlO_zgEACAAJ&dq=QCPBDwAAQBAJ&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Skyward_Flight_The_Collection.html?hl=&id=JlO_zgEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=JlO_zgEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The tales of FM, Alanik, and Jorgen combine to expand the universe of the New York Times bestselling Skyward series to new action-packed heights. Once you&#39;ve claimed the stars, can you keep them free?"
+              }
+            }
+          ]
+        }
+  recorded_at: Sat, 10 Dec 2022 19:05:29 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/Types_QueryType/google_books_by_title/will_return_google_books_matching_title_argument.yml
+++ b/spec/fixtures/Types_QueryType/google_books_by_title/will_return_google_books_matching_title_argument.yml
@@ -1145,4 +1145,889 @@ http_interactions:
           ]
         }
   recorded_at: Fri, 09 Dec 2022 21:29:00 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/books/v1/volumes/?key=<key>&q=Rhythm%20of%20War
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sat, 10 Dec 2022 19:05:29 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "kind": "books#volumes",
+          "totalItems": 1843,
+          "items": [
+            {
+              "kind": "books#volume",
+              "id": "QCPBDwAAQBAJ",
+              "etag": "umF9b+UgN8k",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/QCPBDwAAQBAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "subtitle": "Book Four of The Stormlight Archive",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2020-11-17",
+                "description": "An instant #1 New York Times Bestseller and a USA Today and Indie Bestseller! The Stormlight Archive saga continues in Rhythm of War, the eagerly awaited sequel to Brandon Sanderson's #1 New York Times bestselling Oathbringer, from an epic fantasy writer at the top of his game. After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar’s crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin’s scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition’s envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781429952040"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1429952040"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 1374,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 11,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.14.11.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=QCPBDwAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=QCPBDwAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=1&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 15.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=QCPBDwAAQBAJ&rdid=book-QCPBDwAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 15990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=QCPBDwAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "481EEAAAQBAJ",
+              "etag": "xuCVXgvtyDc",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/481EEAAAQBAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "subtitle": "Book Four of The Stormlight Archive",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Fantasy",
+                "publishedDate": "2022-06-28",
+                "description": "The fourth book in the stormlight Archive series, Rhythm of War, marks the eagerly awaited sequel to the #1 New York Times bestselling Oathbringer, from epic fantasy writer Brandon Sanderson. After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar’s crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin’s scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition’s envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780765365309"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0765365308"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 0,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=481EEAAAQBAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=481EEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=481EEAAAQBAJ&dq=Rhythm+of+War&hl=&cd=2&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=481EEAAAQBAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War.html?hl=&id=481EEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=481EEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The fourth book in the stormlight Archive series, Rhythm of War, marks the eagerly awaited sequel to the #1 New York Times bestselling Oathbringer, from epic fantasy writer Brandon Sanderson."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "N093zgEACAAJ",
+              "etag": "A1PqfXhSYqQ",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/N093zgEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War Part Two",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Gollancz",
+                "publishedDate": "2022-04-28",
+                "description": "After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar's crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin's scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition's envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. The story will continue . . . Other books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0575093420"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780575093423"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 752,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=N093zgEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=N093zgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=N093zgEACAAJ&dq=Rhythm+of+War&hl=&cd=3&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=N093zgEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_Part_Two.html?hl=&id=N093zgEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=N093zgEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Brandon Sanderson&#39;s The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "PTBQEAAAQBAJ",
+              "etag": "l92+0ar4BuM",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/PTBQEAAAQBAJ",
+              "volumeInfo": {
+                "title": "The Lost Metal",
+                "subtitle": "A Mistborn Novel",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2022-11-15",
+                "description": "Return to #1 New York Times bestseller Brandon Sanderson’s Mistborn world of Scadrial as its second era, which began with The Alloy of Law, comes to its earth-shattering conclusion in The Lost Metal. For years, frontier lawman turned big-city senator Waxillium Ladrian has hunted the shadowy organization the Set—with his late uncle and his sister among their leaders—since they started kidnapping people with the power of Allomancy in their bloodlines. When Detective Marasi Colms and her partner Wayne find stockpiled weapons bound for the Outer City of Bilming, this opens a new lead. Conflict between Elendel and the Outer Cities only favors the Set, and their tendrils now reach to the Elendel Senate—whose corruption Wax and Steris have sought to expose—and Bilming is even more entangled. After Wax discovers a new type of explosive that can unleash unprecedented destruction and realizes that the Set must already have it, an immortal kandra serving Scadrial’s god, Harmony, reveals that Bilming has fallen under the influence of another god: Trell, worshipped by the Set. And Trell isn’t the only factor at play from the larger Cosmere—Marasi is recruited by offworlders with strange abilities who claim their goal is to protect Scadrial...at any cost. Wax must choose whether to set aside his rocky relationship with God and once again become the Sword that Harmony has groomed him to be. If no one steps forward to be the hero Scadrial needs, the planet and its millions of people will come to a sudden and calamitous ruin. Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Dawnshard (Novella) Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning The Lost Metal Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker The Alcatraz vs. the Evil Librarians series Alcatraz vs. the Evil Librarians The Scrivener's Bones The Knights of Crystallia The Shattered Lens The Dark Talent The Rithmatist series The Rithmatist Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780765391209"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0765391201"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 541,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.6.5.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=PTBQEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=PTBQEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=PTBQEAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=4&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=PTBQEAAAQBAJ&rdid=book-PTBQEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=PTBQEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Other Tor books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer Dawnshard (Novella) Rhythm of War The Mistborn trilogy Mistborn: The Final Empire The Well of ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "90nDzQEACAAJ",
+              "etag": "i8oM4N4jM10",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/90nDzQEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War SIGNED EDITION",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publishedDate": "2020-11-17",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125079367X"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250793676"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 1232,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=90nDzQEACAAJ&dq=Rhythm+of+War&hl=&cd=5&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=90nDzQEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_SIGNED_EDITION.html?hl=&id=90nDzQEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=90nDzQEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The Stormlight Archive saga continues in Rhythm of War, the eagerly awaited sequel to Brandon Sanderson&#39;s #1 New York Times bestselling Oathbringer , from an epic fantasy writer at the top of his game.After forming a coalition of human ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "7mVUEAAAQBAJ",
+              "etag": "Nxdo1zLaJ9s",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/7mVUEAAAQBAJ",
+              "volumeInfo": {
+                "title": "Leech",
+                "authors": [
+                  "Hiron Ennes"
+                ],
+                "publisher": "Tordotcom",
+                "publishedDate": "2022-09-27",
+                "description": "A surreal and horrifying debut, Hiron Ennes's Leech defies our understanding of identity, heredity, and bodily autonomy. An Amazon Book of the Month! “A wonderful new entry to Gothic science fiction, impeccably clever and atmospheric. Think Wuthering Heights... with worms!”—Tamsyn Muir MEET THE CURE FOR THE HUMAN DISEASE In an isolated chateau, as far north as north goes, the baron’s doctor has died. The doctor’s replacement has a mystery to solve: discovering how the Institute lost track of one of its many bodies. For hundreds of years the Interprovincial Medical Institute has grown by taking root in young minds and shaping them into doctors, replacing every human practitioner of medicine. The Institute is here to help humanity, to cure and to cut, to cradle and protect the species from the apocalyptic horrors their ancestors unleashed. In the frozen north, the Institute's body will discover a competitor for its rung at the top of the evolutionary ladder. A parasite is spreading through the baron's castle, already a dark pit of secrets, lies, violence, and fear. The two will make war on the battlefield of the body. Whichever wins, humanity will lose again. At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250811196"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1250811198"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 230,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 3,
+                "ratingsCount": 2,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.2.2.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=7mVUEAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=7mVUEAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=7mVUEAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=6&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=7mVUEAAAQBAJ&rdid=book-7mVUEAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=7mVUEAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": ". . I will follow this writer anywhere going forward.&quot; —Gillian Flynn, New York Times bestselling author of Gone Girl A surreal and horrifying debut, Hiron Ennes&#39;s Leech defies our understanding of identity, heredity, and bodily autonomy."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "NNt9zgEACAAJ",
+              "etag": "nQjKqDa47kQ",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/NNt9zgEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War Part One",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Gollancz",
+                "publishedDate": "2021-10",
+                "description": "After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war. Neither side has gained an advantage, and the threat of a betrayal by Dalinar's crafty ally Taravangian looms over every strategic move. Now, as new technological discoveries by Navani Kholin's scholars begin to change the face of the war, the enemy prepares a bold and dangerous operation. The arms race that follows will challenge the very core of the Radiant ideals, and potentially reveal the secrets of the ancient tower that was once the heart of their strength. At the same time that Kaladin Stormblessed must come to grips with his changing role within the Knights Radiant, his Windrunners face their own problem: As more and more deadly enemy Fused awaken to wage war, no more honorspren are willing to bond with humans to increase the number of Radiants. Adolin and Shallan must lead the coalition's envoy to the honorspren stronghold of Lasting Integrity and either convince the spren to join the cause against the evil god Odium, or personally face the storm of failure. The story continues in Rhythm of War Part Two. Other books by Brandon Sanderson The Cosmere The Stormlight Archive The Way of Kings Words of Radiance Edgedancer (Novella) Oathbringer The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Collection Arcanum Unbounded Other Cosmere novels Elantris Warbreaker Other books by Brandon Sanderson The Reckoners Steelheart Firefight Calamity",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "0575093412"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9780575093416"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "pageCount": 672,
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=NNt9zgEACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=NNt9zgEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=NNt9zgEACAAJ&dq=Rhythm+of+War&hl=&cd=7&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=NNt9zgEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War_Part_One.html?hl=&id=NNt9zgEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=NNt9zgEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "Brandon Sanderson&#39;s The Cosmere The Mistborn trilogy Mistborn: The Final Empire The Well of Ascension The Hero of Ages Mistborn: The Wax and Wayne series Alloy of Law Shadows of Self Bands of Mourning Other Cosmere novels Elantris ..."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "q-przQEACAAJ",
+              "etag": "N9OFXEvLlCE",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/q-przQEACAAJ",
+              "volumeInfo": {
+                "title": "Rhythm of War",
+                "authors": [
+                  "Brandon Sanderson"
+                ],
+                "publisher": "Tor Books",
+                "publishedDate": "2020-11-04",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "1250784263"
+                  },
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250784261"
+                  }
+                ],
+                "readingModes": {
+                  "text": false,
+                  "image": false
+                },
+                "printType": "BOOK",
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "preview-1.0.0",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=q-przQEACAAJ&dq=Rhythm+of+War&hl=&cd=8&source=gbs_api",
+                "infoLink": "http://books.google.com/books?id=q-przQEACAAJ&dq=Rhythm+of+War&hl=&source=gbs_api",
+                "canonicalVolumeLink": "https://books.google.com/books/about/Rhythm_of_War.html?hl=&id=q-przQEACAAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "NOT_FOR_SALE",
+                "isEbook": false
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "NO_PAGES",
+                "embeddable": false,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": false
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=q-przQEACAAJ&hl=&source=gbs_api",
+                "accessViewStatus": "NONE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "&quot;After forming a coalition of human resistance against the enemy invasion, Dalinar Kholin and his Knights Radiant have spent a year fighting a protracted, brutal war."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "E649EAAAQBAJ",
+              "etag": "QgPeW5o+FYo",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/E649EAAAQBAJ",
+              "volumeInfo": {
+                "title": "The Wilderwomen",
+                "subtitle": "A Novel",
+                "authors": [
+                  "Ruth Emmie Lang"
+                ],
+                "publisher": "St. Martin's Press",
+                "publishedDate": "2022-11-15",
+                "description": "\"Exquisitely drawn characters imbue Lang’s unconventional plot with verisimilitude and heart, inspiring readers to ponder whether the world is stranger and more beautiful than it appears. Effervescent, ethereal, and suffused with wonder.\" — Kirkus (starred review) \"Lang’s melancholy, atmospheric writing sets the perfect tone as the Wilder sisters unravel the mystery. The result is a cozy supernatural outing perfect for an autumn night.\" —Publisher's Weekly Ohioana Book Award finalist Ruth Emmie Lang returns with a new cast of ordinary characters with extraordinary abilities in The Wilderwomen. Five years ago, Nora Wilder disappeared. The older of her two daughters, Zadie, should have seen it coming, because she can literally see things coming. But not even her psychic abilities were able to prevent their mother from vanishing one morning. Zadie’s estranged younger sister, Finn, can’t see into the future, but she has an uncannily good memory, so good that she remembers not only her own memories, but the echoes of memories other people have left behind. On the afternoon of her graduation party, Finn is seized by an “echo” more powerful than anything she’s experienced before: a woman singing a song she recognizes, a song about a bird... When Finn wakes up alone in an aviary with no idea of how she got there, she realizes who the memory belongs to: Nora. Now, it’s up to Finn to convince her sister that not only is their mom still out there, but that she wants to be found. Against Zadie’s better judgement, she and Finn hit the highway, using Finn’s echoes to retrace Nora’s footsteps and uncover the answer to the question that has been haunting them for years: Why did she leave? But the more time Finn spends in their mother’s past, the harder it is for her to return to the present, to return to herself. As Zadie feels her sister start to slip away, she will have to decide what lengths she is willing to go to find their mother, knowing that if she chooses wrong, she could lose them both for good.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250246929"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125024692X"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 266,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 2,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": false,
+                "contentVersion": "1.1.1.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=E649EAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=E649EAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=E649EAAAQBAJ&printsec=frontcover&dq=Rhythm+of+War&hl=&cd=9&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=E649EAAAQBAJ&rdid=book-E649EAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true,
+                  "acsTokenLink": "http://books.google.com/books/download/The_Wilderwomen-sample-epub.acsm?id=E649EAAAQBAJ&format=epub&output=acs4_fulfillment_token&dl_type=sample&source=gbs_api"
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=E649EAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "The result is a cozy supernatural outing perfect for an autumn night.&quot; —Publisher&#39;s Weekly Ohioana Book Award finalist Ruth Emmie Lang returns with a new cast of ordinary characters with extraordinary abilities in The Wilderwomen."
+              }
+            },
+            {
+              "kind": "books#volume",
+              "id": "Ulk8EAAAQBAJ",
+              "etag": "aYz1+CUwnIg",
+              "selfLink": "https://www.googleapis.com/books/v1/volumes/Ulk8EAAAQBAJ",
+              "volumeInfo": {
+                "title": "Seasonal Fears",
+                "authors": [
+                  "Seanan McGuire"
+                ],
+                "publisher": "Tordotcom",
+                "publishedDate": "2022-05-03",
+                "description": "From New York Times bestselling author Seanan McGuire, Seasonal Fears is the extraordinary companion novel to Middlegame. The king of winter and the queen of summer are dead. The fight for their crowns begins! Melanie has a destiny, though it isn’t the one everyone assumes it to be. She’s delicate; she’s fragile; she’s dying. Now, truly, is the winter of her soul. Harry doesn’t want to believe in destiny, because that means accepting the loss of the one person who gives his life meaning, who brings summer to his world. So, when a new road is laid out in front of them—a road that will lead through untold dangers toward a possible lifetime together—walking down it seems to be the only option. But others are following behind, with violence in their hearts. It looks like Destiny has a plan for them, after all.... \"One must maintain a little bit of summer even in the middle of winter.\" —Thoreau At the Publisher's request, this title is being sold without Digital Rights Management Software (DRM) applied.",
+                "industryIdentifiers": [
+                  {
+                    "type": "ISBN_13",
+                    "identifier": "9781250768254"
+                  },
+                  {
+                    "type": "ISBN_10",
+                    "identifier": "125076825X"
+                  }
+                ],
+                "readingModes": {
+                  "text": true,
+                  "image": false
+                },
+                "pageCount": 544,
+                "printType": "BOOK",
+                "categories": [
+                  "Fiction"
+                ],
+                "averageRating": 4,
+                "ratingsCount": 3,
+                "maturityRating": "NOT_MATURE",
+                "allowAnonLogging": true,
+                "contentVersion": "1.1.1.0.preview.2",
+                "panelizationSummary": {
+                  "containsEpubBubbles": false,
+                  "containsImageBubbles": false
+                },
+                "imageLinks": {
+                  "smallThumbnail": "http://books.google.com/books/content?id=Ulk8EAAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl&source=gbs_api",
+                  "thumbnail": "http://books.google.com/books/content?id=Ulk8EAAAQBAJ&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api"
+                },
+                "language": "en",
+                "previewLink": "http://books.google.com/books?id=Ulk8EAAAQBAJ&pg=PP1&dq=Rhythm+of+War&hl=&cd=10&source=gbs_api",
+                "infoLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ&source=gbs_api",
+                "canonicalVolumeLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ"
+              },
+              "saleInfo": {
+                "country": "US",
+                "saleability": "FOR_SALE",
+                "isEbook": true,
+                "listPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "retailPrice": {
+                  "amount": 14.99,
+                  "currencyCode": "USD"
+                },
+                "buyLink": "https://play.google.com/store/books/details?id=Ulk8EAAAQBAJ&rdid=book-Ulk8EAAAQBAJ&rdot=1&source=gbs_api",
+                "offers": [
+                  {
+                    "finskyOfferType": 1,
+                    "listPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "retailPrice": {
+                      "amountInMicros": 14990000,
+                      "currencyCode": "USD"
+                    },
+                    "giftable": true
+                  }
+                ]
+              },
+              "accessInfo": {
+                "country": "US",
+                "viewability": "PARTIAL",
+                "embeddable": true,
+                "publicDomain": false,
+                "textToSpeechPermission": "ALLOWED",
+                "epub": {
+                  "isAvailable": true
+                },
+                "pdf": {
+                  "isAvailable": false
+                },
+                "webReaderLink": "http://play.google.com/books/reader?id=Ulk8EAAAQBAJ&hl=&source=gbs_api",
+                "accessViewStatus": "SAMPLE",
+                "quoteSharingAllowed": false
+              },
+              "searchInfo": {
+                "textSnippet": "From New York Times bestselling author Seanan McGuire, Seasonal Fears is the extraordinary companion novel to Middlegame."
+              }
+            }
+          ]
+        }
+  recorded_at: Sat, 10 Dec 2022 19:05:29 GMT
 recorded_with: VCR 6.1.0

--- a/spec/graphql/mutations/books/create_book_spec.rb
+++ b/spec/graphql/mutations/books/create_book_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 module Mutations
   module Books
     RSpec.describe CreateBook, type: :request do
+      before :each do 
+        @user_1 = User.create!(name: "Tester 1", zipcode: "80241", email: "test1@gmail.com")
+      end
       describe 'book creation' do
         it 'creates and returns a book' do
           expect(Book.count).to eq(0)
@@ -31,6 +34,7 @@ module Mutations
                 category: "Fiction"
                 condition: "Excellent"
                 available: true
+                userId: #{@user_1.id}
               }){
               book {
                 id,


### PR DESCRIPTION
### Description
Now when creating a book you also have to pass in the user id which will automatically create the 'OWNED' relationship between the user and the book being created.


### Type of Change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Fixes Issue #**add issue/card number**
N/A

### Changes Made
Added creation of UserBook to Book Creation.

### Tests Added
Updated test to pass in an ID on book creation.

### Self Review Checklist
- [x] I have self-reviewed my code
- [x] I have written tests for each change
- [x] Changes pass all tests locally

![image](https://user-images.githubusercontent.com/59062958/206872639-9b65b918-4087-4c66-9605-c03b8a1adcfc.jpeg)

